### PR TITLE
Delete docker-args-build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@
 # This file lists all individuals having contributed content to the repository.
 #
 michaelshobbs <github@psudo.net>
+maxemiliang <github@maxemiliang.me>

--- a/docker-args-build
+++ b/docker-args-build
@@ -1,1 +1,0 @@
-docker-args

--- a/docker-args-deploy
+++ b/docker-args-deploy
@@ -1,1 +1,0 @@
-docker-args


### PR DESCRIPTION
This will fix errors on push.
If you try to push a Dockerfile build to a dokku server using this plugin it will error out with:
`remote: unknown flag: --log-driver
remote: See 'docker build --help'.`

This will fix it as it will not run on docker build.